### PR TITLE
Update queries conforming to latest nvim-treesitter

### DIFF
--- a/lua/pkl-neovim/internal.lua
+++ b/lua/pkl-neovim/internal.lua
@@ -21,7 +21,7 @@ function M.init()
       install_info = {
         url = "https://github.com/apple/tree-sitter-pkl.git",
         -- TODO(oss): Check accessibility once repository is public
-        revision = "c03f04a313b712f8ab00a2d862c10b37318699ae",
+        revision = "b79c8c4d2419e82324d9aca31e9de47ed8304f1f",
         files = {"src/parser.c", "src/scanner.c"},
         filetype = "pkl",
         used_by = {"pcf"}

--- a/queries/pkl/highlights.scm
+++ b/queries/pkl/highlights.scm
@@ -44,7 +44,15 @@
 (parameterList (typedIdentifier (identifier) @variable.parameter))
 (objectBodyParameters (typedIdentifier (identifier) @variable.parameter))
 
-(identifier) @variable
+(annotation (qualifiedIdentifier) @attribute)
+(forGenerator (typedIdentifier (identifier) @variable))
+(letExpr (typedIdentifier (identifier) @variable))
+(variableExpr (identifier) @variable)
+(importClause (identifier) @variable)
+(variableObjectLiteral (identifier) @variable)
+(propertyCallExpr (identifier) @variable)
+
+; (identifier) @variable
 
 ; Literals
 
@@ -52,7 +60,7 @@
 (slStringLiteral) @string
 (mlStringLiteral) @string
 
-(escapeSequence) @escape
+(escapeSequence) @string.escape
 
 (intLiteral) @number
 (floatLiteral) @number
@@ -100,6 +108,8 @@
 "|"  @operator.type
 "->" @operator.type
 
+"..." @punctuation
+"...?" @punctuation
 "," @punctuation.delimiter
 ":" @punctuation.delimiter
 "." @punctuation.delimiter

--- a/queries/pkl/highlights.scm
+++ b/queries/pkl/highlights.scm
@@ -67,15 +67,15 @@
 
 (interpolationExpr
   "\\(" @punctuation.special
-  ")" @punctuation.special) @embedded
+  ")" @punctuation.special) @none
 
 (interpolationExpr
  "\\#(" @punctuation.special
- ")" @punctuation.special) @embedded
+ ")" @punctuation.special) @none
 
 (interpolationExpr
   "\\##(" @punctuation.special
-  ")" @punctuation.special) @embedded
+  ")" @punctuation.special) @none
 
 (lineComment) @comment
 (blockComment) @comment
@@ -136,15 +136,12 @@
 "function" @keyword.function
 "hidden" @keyword
 "if" @keyword.conditional
-(importExpr "import" @module)
-(importGlobExpr "import*" @module)
 "import" @keyword.import
 "import*" @keyword.import
 "in" @keyword
 "is" @keyword
 "let" @keyword
 "local" @keyword
-(moduleExpr "module" @type.builtin)
 "module" @keyword
 "new" @keyword
 "nothing" @type.builtin

--- a/queries/pkl/highlights.scm
+++ b/queries/pkl/highlights.scm
@@ -20,43 +20,31 @@
 (clazz (identifier) @type)
 (typeAlias (identifier) @type)
 ((identifier) @type
- (match? @type "^[A-Z]"))
+ (#match? @type "^[A-Z]"))
 
 (typeArgumentList
   "<" @punctuation.bracket
   ">" @punctuation.bracket)
 
-(typeParameter (identifier) @type)
-(typeAnnotation (type (qualifiedIdentifier) @type))
-(newExpr (type (qualifiedIdentifier) @type))
-
 ; Method calls
 
 (methodCallExpr
-  (identifier) @method)
+  (identifier) @function.call)
 
 ; Method definitions
 
-(classMethod (methodHeader (identifier)) @method)
-(objectMethod (methodHeader (identifier)) @method)
+(classMethod (methodHeader (identifier)) @function.method)
+(objectMethod (methodHeader (identifier)) @function.method)
 
 ; Identifiers
 
 (classProperty (identifier) @property)
 (objectProperty (identifier) @property)
 
-(parameterList (typedIdentifier (identifier) @parameter))
-(objectBodyParameters (typedIdentifier (identifier) @parameter))
+(parameterList (typedIdentifier (identifier) @variable.parameter))
+(objectBodyParameters (typedIdentifier (identifier) @variable.parameter))
 
-(annotation (qualifiedIdentifier) @attribute)
-(forGenerator (typedIdentifier (identifier) @variable))
-(letExpr (typedIdentifier (identifier) @variable))
-(variableExpr (identifier) @variable)
-(importClause (identifier) @variable)
-(variableObjectLiteral (identifier) @variable)
-(propertyCallExpr (identifier) @variable)
-
-; (identifier) @variable
+(identifier) @variable
 
 ; Literals
 
@@ -64,31 +52,31 @@
 (slStringLiteral) @string
 (mlStringLiteral) @string
 
-(escapeSequence) @string.escape
+(escapeSequence) @escape
 
 (intLiteral) @number
 (floatLiteral) @number
 
 (interpolationExpr
   "\\(" @punctuation.special
-  ")" @punctuation.special) @none
+  ")" @punctuation.special) @embedded
 
 (interpolationExpr
  "\\#(" @punctuation.special
- ")" @punctuation.special) @none
-  
+ ")" @punctuation.special) @embedded
+
 (interpolationExpr
   "\\##(" @punctuation.special
-  ")" @punctuation.special) @none
+  ")" @punctuation.special) @embedded
 
 (lineComment) @comment
 (blockComment) @comment
-(docComment) @comment
+(docComment) @comment.documentation
 
 ; Operators
 
 "??" @operator
-"@"  @attribute
+"@"  @operator
 "="  @operator
 "<"  @operator
 ">"  @operator
@@ -112,8 +100,6 @@
 "|"  @operator.type
 "->" @operator.type
 
-"..." @punctuation
-"...?" @punctuation
 "," @punctuation.delimiter
 ":" @punctuation.delimiter
 "." @punctuation.delimiter
@@ -121,7 +107,7 @@
 
 "(" @punctuation.bracket
 ")" @punctuation.bracket
-; "[" @punctuation.bracket TODO: FIGURE OUT HOW TO REFER TO CUSTOM TOKENS
+"[" @punctuation.bracket
 "]" @punctuation.bracket
 "{" @punctuation.bracket
 "}" @punctuation.bracket
@@ -132,21 +118,20 @@
 "amends" @keyword
 "as" @keyword
 "class" @keyword
-"else" @conditional
+"else" @keyword.conditional ; TODO: fix 'else' not highlighting after 'when'
 "extends" @keyword
 "external" @keyword
 (falseLiteral) @boolean
-"for" @repeat
-"function" @keyword
+"for" @keyword.repeat
+"function" @keyword.function
 "hidden" @keyword
-"if" @conditional
-(importExpr "import" @include)
-(importGlobExpr "import*" @include)
-(importClause "import" @include)
-(importGlobClause "import*" @include)
-(importClause "as" @include)
-"in" @repeat
-"is" @keyword.operator
+"if" @keyword.conditional
+(importExpr "import" @module)
+(importGlobExpr "import*" @module)
+"import" @keyword.import
+"import*" @keyword.import
+"in" @keyword
+"is" @keyword
 "let" @keyword
 "local" @keyword
 (moduleExpr "module" @type.builtin)
@@ -157,14 +142,14 @@
 "open" @keyword
 "out" @keyword
 (outerExpr) @variable.builtin
-"read" @function.builtin
-"read?" @function.builtin
-"read*" @function.builtin
+"read" @function.method.builtin
+"read?" @function.method.builtin
+"read*" @function.method.builtin
 "super" @variable.builtin
 (thisExpr) @variable.builtin
-"throw" @function.builtin
-"trace" @function.builtin
+"throw" @function.method.builtin
+"trace" @function.method.builtin
 (trueLiteral) @boolean
 "typealias" @keyword
 "unknown" @type.builtin
-"when" @conditional
+"when" @keyword.conditional

--- a/queries/pkl/indents.scm
+++ b/queries/pkl/indents.scm
@@ -16,14 +16,19 @@
   (objectBody)
   (classBody)
   (ifExpr)
-  (mlStringLiteral) ; This isn't perfect; newlines are too indented but it's better than if omitted.
-] @indent
+  (mlStringLiteral)
+  (importClause)
+  (importGlobClause)
+] @indent.begin
+
+
+("\"\"\"") @indent.begin @indent.end ; fix for mlString's delimiter
 
 [
-  "("
-  ")"
-  "{"
   "}"
-  "if"
+  "]"
+  ")"
   "else"
-] @branch ; TODO: what does this query do?
+] @indent.branch @indent.end
+
+

--- a/queries/pkl/injections.scm
+++ b/queries/pkl/injections.scm
@@ -17,7 +17,7 @@
 ; * string delimiters are considered part of the regex
 (
   ((methodCallExpr (identifier) @methodName (argumentList (slStringLiteral) @injection.content))
-    (set! injection.language "regex"))
-  (eq? @methodName "Regex"))
+    (#set! injection.language "regex"))
+  (#eq? @methodName "Regex"))
  
 ; TODO: inject markdown into doc comments


### PR DESCRIPTION
Updated versions of queries for nvim-treesitter (#2). 

tree-sitter-pkl version in `internal.lua` had to be updated to support opening square bracket capture.
Highlights and indents are still not perfect but it's a start.