### PR TITLE
Remove foldmethod line

### DIFF
--- a/ftplugin/pkl.vim
+++ b/ftplugin/pkl.vim
@@ -13,7 +13,6 @@
 " limitations under the License.
 
 " Fold using tree-sitter
-setlocal foldmethod=expr
 setlocal foldexpr=nvim_treesitter#foldexpr()
 
 " comment with two slashes


### PR DESCRIPTION
This removes `foldmethod`, allowing the fold method to fall back to a user-defined setting.

Setting `foldmethod=expr` has the unwanted side-effect of auto-folding all folding zones when opening a Pkl file.

Closes #4