### PR TITLE
Fix locals.scm for vim-illuminate

### DIFF
--- a/queries/pkl/locals.scm
+++ b/queries/pkl/locals.scm
@@ -41,7 +41,6 @@
 (objectProperty
   (identifier) @local.definition)
 
-
 (typedIdentifier 
   (identifier) @local.definition)
 

--- a/queries/pkl/locals.scm
+++ b/queries/pkl/locals.scm
@@ -41,6 +41,7 @@
 (objectProperty
   (identifier) @local.definition)
 
+
 (typedIdentifier 
   (identifier) @local.definition)
 

--- a/queries/pkl/locals.scm
+++ b/queries/pkl/locals.scm
@@ -33,13 +33,13 @@
 (classMethod (methodHeader (identifier)) @local.definition)
 
 (objectMethod
-  (identifier) @local.definition)
-  
-(classProperty
   (methodHeader (identifier)) @local.definition)
 
+(classProperty
+  (identifier) @local.definition)
+
 (objectProperty
-  (methodHeader (identifier)) @local.definition)
+  (identifier) @local.definition)
 
 (typedIdentifier 
   (identifier) @local.definition)


### PR DESCRIPTION
When I install [vim-illuminate](https://github.com/RRethy/vim-illuminate) and open a `.pkl` file, I get the following error:

```
vim-illuminate: An internal error has occured: false"...cal/nvim/share/nvim/runtime/lua/vim/treesitter/query.lua:252: Query error at 36:3. Impossible pattern:\n  (identifier) @local.definition)\n  ^\n"
```

This PR will fix it.