### PR TITLE
Fix lazy.nvim install instructions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -89,6 +89,8 @@ This config is compatible with {uri-lazyvim}[LazyVim].
     "L3MON4D3/LuaSnip",
   },
   build = function()
+    require('pkl-neovim.internal').init()
+
     -- Set up syntax highlighting.
     vim.cmd("TSInstall! pkl")
   end,


### PR DESCRIPTION
In order to ensure that lazy.nvim correctly extends treesitter to include the pkl parser, this commit requires the treesitter extension code in the plugin during the plugin build step. This is required as the plugin is not loaded during building.