### PR TITLE
Configure `hawkeye` to update license headers

### DIFF
--- a/.circleci/config.pkl
+++ b/.circleci/config.pkl
@@ -1,4 +1,4 @@
-amends "package://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.circleci@1.0.2#/PklCI.pkl"
+amends "package://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.circleci@1.2.0#/PklCI.pkl"
 
 triggerDocsBuild = "release"
 

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -1,0 +1,30 @@
+additionalHeaders = ["scripts/custom-header-style.toml"]
+
+headerPath = "scripts/license-header.txt"
+
+includes = [
+    "*.scm",
+    "*.vim",
+    "*.snippets",
+]
+
+excludes = [
+    "doc",
+    "docs",
+]
+
+[git]
+attrs = 'auto'
+ignore = 'auto'
+
+[properties]
+copyrightOwner = "Apple Inc. and the Pkl project authors"
+
+[mapping.SCHEME_STYLE]
+extensions = ["scm"]
+
+[mapping.VIM_STYLE]
+extensions = ["vim"]
+
+[mapping.SCRIPT_STYLE]
+extensions = ["snippets"]

--- a/scripts/custom-header-style.toml
+++ b/scripts/custom-header-style.toml
@@ -1,0 +1,23 @@
+[SCHEME_STYLE]
+firstLine = ''
+endLine = "\n"
+beforeEachLine = '; '
+afterEachLine = ''
+allowBlankLines = false
+multipleLines = false
+padLines = false
+skipLinePattern = '^;!.*$'
+firstLineDetectionPattern = ';.*$'
+lastLineDetectionPattern = ';.*$'
+
+[VIM_STYLE]
+firstLine = ''
+endLine = "\n"
+beforeEachLine = '" '
+afterEachLine = ''
+allowBlankLines = false
+multipleLines = false
+padLines = false
+skipLinePattern = '^\"!.*$'
+firstLineDetectionPattern = '\".*$'
+lastLineDetectionPattern = '\".*$'

--- a/scripts/license-header.txt
+++ b/scripts/license-header.txt
@@ -1,0 +1,13 @@
+Copyright ©{{ " " }}{%- if attrs.git_file_modified_year != attrs.git_file_created_year -%}{{ attrs.git_file_created_year }}-{{ attrs.git_file_modified_year }}{%- else -%}{{ attrs.git_file_created_year }}{%- endif -%}{{ " " }}{{ props["copyrightOwner"] }}. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
Adds configuration to format/check license headers with `hawkeye`.

Additionally, ran the formatter on license headers that needed to be updated.