### PR TITLE
Bump tree-sitter-pkl to 0.18.1, update queries

### DIFF
--- a/lua/pkl-neovim.lua
+++ b/lua/pkl-neovim.lua
@@ -49,7 +49,7 @@ function M.init_grammar()
     parsers.get_parser_configs().pkl = {
       install_info = {
         url = "https://github.com/apple/tree-sitter-pkl.git",
-        revision = "0.17.0",
+        revision = "v0.18.1",
         files = {"src/parser.c", "src/scanner.c"},
         filetype = "pkl",
         used_by = {"pcf"}

--- a/queries/pkl/highlights.scm
+++ b/queries/pkl/highlights.scm
@@ -26,10 +26,18 @@
   "<" @punctuation.bracket
   ">" @punctuation.bracket)
 
-; Method calls
+; Access
+(unqualifiedAccessExpr
+  (identifier) @property)
 
-(methodCallExpr
-  (identifier) @function.call)
+(qualifiedAccessExpr
+  (identifier) @variable.member)
+
+(qualifiedAccessExpr
+  (identifier) @function.call (argumentList))
+
+(unqualifiedAccessExpr
+  (identifier) @function.call (argumentList))
 
 ; Method definitions
 
@@ -38,42 +46,37 @@
 
 ; Identifiers
 
-(classProperty (identifier) @property)
-(objectProperty (identifier) @property)
+(classProperty (identifier) @variable.member)
+(objectProperty (identifier) @variable.member)
 
-(parameterList (typedIdentifier (identifier) @variable.parameter))
-(objectBodyParameters (typedIdentifier (identifier) @variable.parameter))
+(annotation "@" @attribute (qualifiedIdentifier (identifier) @attribute))
 
-(annotation (qualifiedIdentifier) @attribute)
-(forGenerator (typedIdentifier (identifier) @variable))
-(letExpr (typedIdentifier (identifier) @variable))
-(variableExpr (identifier) @variable)
+(typedIdentifier (identifier) @variable.parameter)
+(blankIdentifier) @variable.parameter.builtin
 (importClause (identifier) @variable)
-(variableObjectLiteral (identifier) @variable)
-(propertyCallExpr (identifier) @variable)
 
 ; (identifier) @variable
 
 ; Literals
 
 (stringConstant) @string
-(slStringLiteral) @string
-(mlStringLiteral) @string
+(slStringLiteralExpr) @string
+(mlStringLiteralExpr) @string
 
 (escapeSequence) @string.escape
 
-(intLiteral) @number
-(floatLiteral) @number
+(intLiteralExpr) @number
+(floatLiteralExpr) @number.float
 
-(interpolationExpr
+(stringInterpolation
   "\\(" @punctuation.special
   ")" @punctuation.special) @none
 
-(interpolationExpr
+(stringInterpolation
  "\\#(" @punctuation.special
  ")" @punctuation.special) @none
 
-(interpolationExpr
+(stringInterpolation
   "\\##(" @punctuation.special
   ")" @punctuation.special) @none
 
@@ -84,7 +87,6 @@
 ; Operators
 
 "??" @operator
-"@"  @operator
 "="  @operator
 "<"  @operator
 ">"  @operator
@@ -128,10 +130,10 @@
 "amends" @keyword
 "as" @keyword
 "class" @keyword
-"else" @keyword.conditional ; TODO: fix 'else' not highlighting after 'when'
+"else" @keyword.conditional
 "extends" @keyword
 "external" @keyword
-(falseLiteral) @boolean
+(falseLiteralExpr) @boolean
 "for" @keyword.repeat
 "function" @keyword.function
 "hidden" @keyword
@@ -144,7 +146,7 @@
 "local" @keyword
 "module" @keyword
 "new" @keyword
-(nullLiteral) @constant.builtin
+(nullLiteralExpr) @constant.builtin
 "open" @keyword
 "out" @keyword
 (outerExpr) @variable.builtin
@@ -155,7 +157,7 @@
 (thisExpr) @variable.builtin
 "throw" @function.method.builtin
 "trace" @function.method.builtin
-(trueLiteral) @boolean
+(trueLiteralExpr) @boolean
 "typealias" @keyword
 (nothingType) @type.builtin
 (unknownType) @type.builtin

--- a/queries/pkl/highlights.scm
+++ b/queries/pkl/highlights.scm
@@ -19,8 +19,7 @@
 
 (clazz (identifier) @type)
 (typeAlias (identifier) @type)
-((identifier) @type
- (#match? @type "^[A-Z]"))
+(declaredType (qualifiedIdentifier (identifier) @type))
 
 (typeArgumentList
   "<" @punctuation.bracket
@@ -54,8 +53,6 @@
 (typedIdentifier (identifier) @variable.parameter)
 (blankIdentifier) @variable.parameter.builtin
 (importClause (identifier) @variable)
-
-; (identifier) @variable
 
 ; Literals
 

--- a/queries/pkl/indents.scm
+++ b/queries/pkl/indents.scm
@@ -16,7 +16,7 @@
   (objectBody)
   (classBody)
   (ifExpr)
-  (mlStringLiteral)
+  (mlStringLiteralExpr)
   (importClause)
   (importGlobClause)
 ] @indent.begin

--- a/queries/pkl/injections.scm
+++ b/queries/pkl/injections.scm
@@ -12,10 +12,13 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
-; TODO this doesn't work; why?
 (
-  ((unqualifiedAccessExpr (identifier) @methodName (argumentList (slStringLiteralExpr (slStringLiteralPart) @injection.content (escapeSequence) @injection.content)))
+  ((unqualifiedAccessExpr (identifier) @methodName (argumentList (slStringLiteralExpr (slStringLiteralPart) @injection.content)))
     (#set! injection.language "regex"))
   (#eq? @methodName "Regex"))
 
+(
+  ((unqualifiedAccessExpr (identifier) @methodName (argumentList (slStringLiteralExpr (escapeSequence) @injection.content)))
+    (#set! injection.language "regex"))
+  (#eq? @methodName "Regex"))
 ; TODO: inject markdown into doc comments

--- a/queries/pkl/injections.scm
+++ b/queries/pkl/injections.scm
@@ -12,12 +12,10 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
-; this definition is imprecise in that 
-; * any qualified or unqualified call to a method named "Regex" is considered a regex
-; * string delimiters are considered part of the regex
+; TODO this doesn't work; why?
 (
-  ((methodCallExpr (identifier) @methodName (argumentList (slStringLiteral) @injection.content))
+  ((unqualifiedAccessExpr (identifier) @methodName (argumentList (slStringLiteralExpr (slStringLiteralPart) @injection.content (escapeSequence) @injection.content)))
     (#set! injection.language "regex"))
   (#eq? @methodName "Regex"))
- 
+
 ; TODO: inject markdown into doc comments

--- a/queries/pkl/locals.scm
+++ b/queries/pkl/locals.scm
@@ -18,7 +18,7 @@
 (clazz) @local.scope
 (classMethod) @local.scope
 (objectMethod) @local.scope
-(functionLiteral) @local.scope
+(functionLiteralExpr) @local.scope
 (objectBody) @local.scope
 (letExpr) @local.scope
 (forGenerator) @local.scope
@@ -41,10 +41,10 @@
 (objectProperty
   (identifier) @local.definition)
 
-(typedIdentifier 
+(typedIdentifier
   (identifier) @local.definition)
 
 ; References
 
-(variableExpr 
+(unqualifiedAccessExpr
   (identifier) @local.reference)


### PR DESCRIPTION
This updates the queries to match the breaking changes in the new grammar.

Also, regex injection is now working!

![Screenshot 2025-04-19 at 8 22 42 AM](https://github.com/user-attachments/assets/5530fdcb-67d6-4120-a4cc-0f7cd7607403)
