### PR TITLE
Improve root dir detection logic

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -162,7 +162,20 @@ See `:h vim.g.pkl_neovim` for detailed documentation on all of the available con
 
 == Project syncing
 
-To analyze project dependencies, the Pkl Language Server needs to sync all the PklProjects within the workspace.
+To analyze project dependencies, the Pkl Language Server needs to sync all the PklProjects within the <<workspace-root,workspace root>>.
 
 To do this, run the `:Pkl syncProjects` command.
 Alternatively, run lua function `require('pkl-neovim').sync_projects()`.
+
+[[workspace-root]]
+== Workspace root
+
+When starting {uri-pkl-lsp}[Pkl Language Server], pkl-neovim will look for the following files/directories to determine what the workspace root is (in descending order of priority):
+
+1. `.pkl-lsp/`
+2. `.git/`
+3. `PklProject`
+
+If you are working on a non-git based project, it can be helpful to create a `.pkl-lsp` to mark where the workspace root is.
+This allows the language server to discover multiple Pkl projects, and analyze dependency imports in all of them.
+This also allows pkl-neovim to determine that the same instance of the language server can be shared between different buffers.

--- a/lua/pkl-neovim.lua
+++ b/lua/pkl-neovim.lua
@@ -78,7 +78,13 @@ function M.start_lsp()
     settings = {
       ["pkl.cli.path"] = config.pkl_cli_path
     },
-    root_dir = vim.fs.root(0, {'.git'}),
+    -- first look for a `.pkl-lsp` dir
+    -- failing that, look for a `.git` dir
+    -- failing that, look for a PklProject file
+    root_dir =
+      vim.fs.root(0, {'.pkl-lsp'})
+        or vim.fs.root(0, {'.git'})
+        or vim.fs.root(0, {'PklProject'}),
     cmd = config.start_command,
     handlers = require("pkl-neovim.lsp_extensions"),
     commands = require("pkl-neovim.lsp_commands"),

--- a/lua/pkl-neovim.lua
+++ b/lua/pkl-neovim.lua
@@ -82,9 +82,9 @@ function M.start_lsp()
     -- failing that, look for a `.git` dir
     -- failing that, look for a PklProject file
     root_dir =
-      vim.fs.root(0, {'.pkl-lsp'})
-        or vim.fs.root(0, {'.git'})
-        or vim.fs.root(0, {'PklProject'}),
+      vim.fs.root(0, '.pkl-lsp')
+        or vim.fs.root(0, '.git')
+        or vim.fs.root(0, 'PklProject'),
     cmd = config.start_command,
     handlers = require("pkl-neovim.lsp_extensions"),
     commands = require("pkl-neovim.lsp_commands"),


### PR DESCRIPTION
Not every project is git-based.

This changes the root dir detection logic to first look for a `.pkl-lsp` directory, then a `.git` directory, fall back to looking for a `PklProject` file.

Users that wish to configure the workspace root manually can create a `.pkl-lsp` directory to mark it.

Closes #30 