### PR TITLE
Fix validation of timeout_ms

### DIFF
--- a/doc/pkl-neovim.txt
+++ b/doc/pkl-neovim.txt
@@ -96,7 +96,7 @@ PklNeovimConfig                                               *PklNeovimConfig*
         {pkl_cli_path?}                     (string)
         Local path in your file system where the Pkl CLI is installed.
 
-        {timeout_ms?}                       (integer)
+        {timeout_ms?}                       (number)
         The number of milliseconds to wait for responses from Pkl Language
         Server.
         (Default: 5000)

--- a/lua/pkl-neovim/config.lua
+++ b/lua/pkl-neovim/config.lua
@@ -19,7 +19,7 @@ local M = {}
 
 ---@class pklneovim.Config
 ---@field pkl_cli_path? string
----@field timeout_ms? integer
+---@field timeout_ms? number
 ---@field start_command? string[]
 
 ---@param path string The path to the field being validated
@@ -35,7 +35,7 @@ end
 local function validate(cfg)
   return validate_path("vim.g.pkl_neovim", {
     pkl_cli_path = { cfg.pkl_cli_path, {"string", "nil"} },
-    timeout_ms = { cfg.timeout_ms, {"integer", "nil"} },
+    timeout_ms = { cfg.timeout_ms, {"number", "nil"} },
     start_command = { cfg.start_command, {"table", "nil"} }
   })
 end


### PR DESCRIPTION
Function `vim.validate` accepts `"number"`, but not `"integer"`.

See https://neovim.io/doc/user/luaref.html#lua-type() and https://neovim.io/doc/user/lua.html#vim.validate()